### PR TITLE
Adopt index2 layout with separated styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,26 +3,165 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>kontainer.sh</title>
+    <title>kontainer.sh – DevOps Knowledge</title>
+    <meta
+      name="description"
+      content="Tutorials, Templates &amp; Tools für moderne Infrastruktur – CI/CD, Kubernetes &amp; IaC – immer getestet, immer aktuell."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Titillium+Web:wght@400;700;900&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="container">
-      <header class="hero">
-        <h1>kontainer.sh</h1>
-        <p>Ein frischer Start für alles rund um Container, Cloud und moderne Infrastruktur.</p>
-      </header>
-      <section class="content">
+    <header>
+      <div class="wrap nav" role="navigation" aria-label="Hauptnavigation">
+        <a class="brand" href="#" aria-label="Startseite">
+          <span class="logo" aria-hidden="true"></span>
+          <span>kontainer.sh</span>
+        </a>
+        <nav class="menu" aria-label="Primäre Navigation">
+          <a href="#tutorials">Tutorials</a>
+          <a href="#oss">Open Source</a>
+          <a href="#produkte">Produkte</a>
+          <a href="#newsletter">Newsletter</a>
+          <a class="btn-ghost" href="#kontakt">Kontakt</a>
+          <a class="btn" href="#tutorials">Tutorials entdecken</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="wrap hero">
+        <div class="chip"><span class="ok">✓</span> Alle Beispiele werden in CI ausgeführt &amp; getestet</div>
+        <h1>DevOps Knowledge –<br />immer getestet, immer aktuell.</h1>
         <p>
-          Diese statische Seite ist der Ausgangspunkt für kommende Inhalte. Schau bald wieder
-          vorbei, um mehr über unsere Projekte, Workshops und Ressourcen zu erfahren.
+          Tutorials, Templates &amp; Tools für moderne Infrastruktur. CI/CD, Kubernetes &amp; IaC – mit automatisierten Tests,
+          Badges und Update-Pipelines.
         </p>
-        <a class="cta" href="mailto:hallo@kontainer.sh">Kontakt aufnehmen</a>
+        <div class="hero-actions">
+          <a class="btn" href="#tutorials">Tutorials entdecken</a>
+          <a class="btn-ghost" href="#starter">Starter-Kit herunterladen</a>
+        </div>
+      </section>
+
+      <section class="wrap" aria-labelledby="usp">
+        <div class="grid">
+          <article class="card k" aria-labelledby="usp1">
+            <div class="pill">CI/CD</div>
+            <h3 id="usp1">CI/CD Pipelines</h3>
+            <p class="muted">GitHub Actions, GitLab CI &amp; ArgoCD – praxiserprobte Workflows.</p>
+          </article>
+          <article class="card k" aria-labelledby="usp2">
+            <div class="pill">Kubernetes</div>
+            <h3 id="usp2">Kubernetes Deployments</h3>
+            <p class="muted">Docker → Helm → K8s. Reproduzierbar &amp; skalierbar.</p>
+          </article>
+          <article class="card k" aria-labelledby="usp3">
+            <div class="pill">IaC</div>
+            <h3 id="usp3">IaC Templates</h3>
+            <p class="muted">Terraform/Pulumi-Bausteine für Startups &amp; KMU.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="tutorials" class="wrap" aria-labelledby="tut">
+        <h2 id="tut">Neueste Tutorials</h2>
+        <div class="grid tutorials-grid">
+          <article class="card k">
+            <h3>CI/CD mit GitHub Actions</h3>
+            <p class="muted">Workflows, Secrets, Environments &amp; Deployment-Strategien.</p>
+            <div class="badge">✅ Tested on GHA v4</div>
+          </article>
+          <article class="card k">
+            <h3>Kubernetes in 15 Minuten</h3>
+            <p class="muted">Lokales Cluster mit kind, Deployment &amp; Service.</p>
+            <div class="badge">✅ Tested on K8s v1.31</div>
+          </article>
+          <article class="card k">
+            <h3>Terraform AWS Starter</h3>
+            <p class="muted">Modulare Struktur, Provider, Remote State &amp; Workspaces.</p>
+            <div class="badge">✅ Tested on TF v1.9</div>
+          </article>
+        </div>
+      </section>
+
+      <section class="wrap">
+        <div class="grid">
+          <div id="oss" class="k8">
+            <h2>Open Source Projekte</h2>
+            <div class="grid single-column-grid">
+              <a class="card repo" href="#" aria-label="terraform-aws-starter Repo">
+                <div>
+                  <strong>kontainer-sh/terraform-aws-starter</strong>
+                  <span class="muted">Terraform-Vorlage mit Beispielen und CI.</span>
+                </div>
+                <div class="star">⭐ 112</div>
+              </a>
+              <a class="card repo" href="#" aria-label="k8s-helm-deployments Repo">
+                <div>
+                  <strong>kontainer-sh/k8s-helm-deployments</strong>
+                  <span class="muted">Helm Charts &amp; Best Practices für App-Deployments.</span>
+                </div>
+                <div class="star">⭐ 89</div>
+              </a>
+            </div>
+          </div>
+
+          <aside id="produkte" class="k4" aria-labelledby="prod">
+            <h2 id="prod">Produkte</h2>
+            <div class="grid single-column-grid">
+              <a class="card" href="#">
+                <strong>Terraform Starter Kit</strong>
+                <p class="muted">AWS-Module, Remote State, Pipelines.</p>
+                <div class="price">29 €</div>
+              </a>
+              <a class="card" href="#">
+                <strong>CI/CD Setup – Fixpreis</strong>
+                <p class="muted">In 2 Wochen produktionsreif. GitHub Actions/ArgoCD.</p>
+                <div class="price">2.500 €</div>
+              </a>
+              <a class="card" href="#">
+                <strong>E-Book „CI/CD Basics“</strong>
+                <p class="muted">Der kompakte Einstieg inkl. Checklisten.</p>
+                <div class="price">19 €</div>
+              </a>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section id="newsletter" class="wrap news-wrap" aria-labelledby="nl">
+        <div class="newsbar">
+          <h3 id="nl">Bleib auf dem Laufenden</h3>
+          <p class="muted">Wöchentliche DevOps-Updates – getestet &amp; kompakt.</p>
+          <form class="form" onsubmit="event.preventDefault(); alert('Danke! (Demo)');">
+            <label class="sr-only" for="mail">E-Mail</label>
+            <input class="input" id="mail" type="email" placeholder="deine@adresse.dev" required />
+            <button class="btn" type="submit">Jetzt abonnieren</button>
+          </form>
+        </div>
       </section>
     </main>
-    <footer class="footer">
-      <p>&copy; <span id="year"></span> kontainer.sh &ndash; Alle Rechte vorbehalten.</p>
+
+    <footer>
+      <div class="wrap foot">
+        <div>© <span id="year"></span> kontainer.sh</div>
+        <div class="links">
+          <a href="#">Impressum</a>
+          <span aria-hidden="true">·</span>
+          <a href="#">Datenschutz</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://github.com/kontainer-sh" target="_blank" rel="noopener">GitHub</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+        </div>
+      </div>
     </footer>
+
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>

--- a/style.css
+++ b/style.css
@@ -1,91 +1,454 @@
 :root {
-  color-scheme: light dark;
-  --bg: #0f172a;
-  --bg-light: #f8fafc;
-  --fg: #0f172a;
-  --fg-light: #e2e8f0;
-  --accent: #38bdf8;
-  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --bg: #0c1624;
+  --bg-hero: #0f1b2b;
+  --bg-soft: #112238;
+  --card: #17283f;
+  --card-2: #152234;
+  --line: #243953;
+  --text: #e8f0fb;
+  --muted: #b9c7de;
+  --accent: #2bd3b5;
+  --accent-600: #18b89d;
+  --badge: #b7f3e9;
+  --badge-text: #08332c;
+  --price: #37e0b0;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.35), 0 2px 10px rgba(0, 0, 0, 0.25);
+  --shadow-soft: 0 10px 26px rgba(0, 0, 0, 0.28), 0 1px 6px rgba(0, 0, 0, 0.22);
+  --r: 18px;
+  --r-sm: 14px;
+  --maxw: 1180px;
 }
 
 * {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
 }
 
 body {
-  min-height: 100vh;
-  background: linear-gradient(135deg, var(--bg), #1e293b);
-  color: var(--fg-light);
+  margin: 0;
+  font-family: "Titillium Web", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 700px at 65% -10%, #203050 0%, var(--bg-hero) 55%) no-repeat,
+    var(--bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+.button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.wrap {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 10px;
+  font-weight: 700;
+}
+
+h1 {
+  font-size: clamp(30px, 4.5vw, 54px);
+  line-height: 1.2;
+  letter-spacing: -0.5px;
+  font-family: "Titillium Web", "Inter", system-ui, sans-serif;
+  font-weight: 900;
+}
+
+h2 {
+  font-size: 22px;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: linear-gradient(180deg, rgba(15, 27, 43, 0.96), rgba(15, 27, 43, 0.78));
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: saturate(140%) blur(6px);
+}
+
+.nav {
+  height: 70px;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
 }
 
-@media (prefers-color-scheme: light) {
-  body {
-    background: linear-gradient(135deg, var(--bg-light), #e2e8f0);
-    color: var(--fg);
-  }
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+  letter-spacing: 0.2px;
 }
 
-.container {
-  width: min(960px, 90%);
-  margin: auto;
-  text-align: center;
-  padding: 4rem 0;
+.logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: conic-gradient(from 220deg, #27e5c6, #17b1a0 40%, #0ea3c0 70%, #27e5c6);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.06);
+  font-weight: 800;
+  color: #0d2233;
 }
 
-.hero h1 {
-  font-size: clamp(2.5rem, 5vw, 4rem);
-  letter-spacing: -0.04em;
-  margin-bottom: 1rem;
+.logo::before {
+  content: "k";
+}
+
+.menu {
+  display: flex;
+  gap: 28px;
+  align-items: center;
+}
+
+.menu a {
+  color: var(--muted);
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.menu a:hover {
+  color: #fff;
+}
+
+.btn,
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-weight: 700;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn {
+  background: var(--accent);
+  color: #08232e;
+}
+
+.btn:hover {
+  background: var(--accent-600);
+  transform: translateY(-1px);
+}
+
+.btn-ghost {
+  border-color: #2a415f;
+  color: var(--muted);
+}
+
+.btn-ghost:hover {
+  border-color: #3b5a82;
+  color: #fff;
+}
+
+.hero {
+  padding: 78px 0 24px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: #0f2136;
+  border: 1px solid var(--line);
+  color: #bfe1ff;
+  font-size: 13px;
+  margin-bottom: 14px;
+}
+
+.chip .ok {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #0bbc8a;
 }
 
 .hero p {
-  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
-  line-height: 1.6;
-  max-width: 40ch;
-  margin: 0 auto 2rem;
+  margin: 8px 0 22px;
+  color: #c6d4ea;
+  font-size: 18px;
 }
 
-.content p {
-  font-size: 1.05rem;
-  line-height: 1.7;
-  margin-bottom: 2rem;
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-.cta {
+section {
+  padding: 24px 0;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(12, 1fr);
+}
+
+.card {
+  background: linear-gradient(180deg, var(--card), var(--card-2));
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 18px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+
+.k {
+  grid-column: span 4;
+}
+
+.k6 {
+  grid-column: span 6;
+}
+
+.k8 {
+  grid-column: span 8;
+}
+
+.k12 {
+  grid-column: span 12;
+}
+
+.tutorials-grid {
+  margin-top: 8px;
+}
+
+.single-column-grid {
+  grid-template-columns: 1fr;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.pill {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.85rem 2.5rem;
-  font-weight: 600;
-  font-size: 1.05rem;
-  text-decoration: none;
-  color: var(--bg);
-  background: var(--accent);
+  gap: 8px;
+  padding: 6px 10px;
   border-radius: 999px;
-  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(43, 211, 181, 0.12);
+  border: 1px solid rgba(43, 211, 181, 0.35);
+  color: #bffcf2;
+  font-weight: 700;
+  font-size: 12px;
+  margin-bottom: 10px;
 }
 
-.cta:hover,
-.cta:focus {
-  transform: translateY(-2px);
-  box-shadow: 0 15px 40px rgba(56, 189, 248, 0.5);
+.badge {
+  position: absolute;
+  left: 16px;
+  bottom: 14px;
+  background: var(--badge);
+  color: var(--badge-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 12px;
 }
 
-.footer {
-  padding: 1.5rem 0;
-  text-align: center;
-  font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.8);
+.repo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
 }
 
-@media (prefers-color-scheme: light) {
-  .footer {
-    color: rgba(15, 23, 42, 0.7);
+.repo strong {
+  display: block;
+  font-size: 16px;
+}
+
+.star {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0.95;
+}
+
+.price {
+  color: var(--price);
+  font-weight: 800;
+}
+
+.news-wrap {
+  padding: 10px 0 0;
+}
+
+.newsbar {
+  background: linear-gradient(180deg, var(--card), #122033);
+  border: 1px solid var(--line);
+  border-radius: calc(var(--r) + 6px);
+  box-shadow: var(--shadow);
+  padding: 22px;
+}
+
+.newsbar h3 {
+  margin: 0 0 6px;
+}
+
+.form {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.input {
+  flex: 1 1 360px;
+  min-width: 260px;
+  padding: 14px 16px;
+  border-radius: 999px;
+  background: #0e1b2c;
+  color: #eaf2ff;
+  border: 1px solid #2b415f;
+  outline: none;
+}
+
+.input::placeholder {
+  color: #7e96b8;
+}
+
+footer {
+  padding: 26px 0 48px;
+  color: #c2d2e9;
+  border-top: 1px solid var(--line);
+  margin-top: 20px;
+}
+
+.foot {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.links {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  color: #cfe0ff;
+}
+
+.links a {
+  color: inherit;
+}
+
+.links a:hover {
+  color: #fff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+}
+
+@media (max-width: 1100px) {
+  .k {
+    grid-column: span 6;
+  }
+
+  .k8 {
+    grid-column: span 12;
+  }
+
+  .k6 {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 760px) {
+  .menu {
+    display: none;
+  }
+
+  .k {
+    grid-column: span 12;
+  }
+
+  .hero {
+    padding-top: 56px;
+  }
+
+  .badge {
+    position: static;
+    margin-top: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- replace the landing page markup with the richer navigation, hero, and content sections from index2.html
- move all visual styling into style.css, adding utility classes so the HTML no longer contains inline styles

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d858f2e6308320b7f2975e3cb990ab