### PR TITLE
Add branded header logo and self-host fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,13 @@
       name="description"
       content="Tutorials, Templates &amp; Tools für moderne Infrastruktur – CI/CD, Kubernetes &amp; IaC – immer getestet, immer aktuell."
     />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Titillium+Web:wght@400;700;900&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <header>
       <div class="wrap nav" role="navigation" aria-label="Hauptnavigation">
         <a class="brand" href="#" aria-label="Startseite">
-          <span class="logo" aria-hidden="true"></span>
-          <span>kontainer.sh</span>
+          <img class="logo" src="KONTAINERSH_Logo_horizontal_negativ_RGB.png" alt="kontainer.sh" />
         </a>
         <nav class="menu" aria-label="Primäre Navigation">
           <a href="#tutorials">Tutorials</a>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,35 @@
+@font-face {
+  font-family: "Titillium Web";
+  src: url("./TitilliumWeb-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Titillium Web";
+  src: url("./TitilliumWeb-SemiBold.ttf") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Titillium Web";
+  src: url("./TitilliumWeb-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Titillium Web";
+  src: url("./TitilliumWeb-Black.ttf") format("truetype");
+  font-weight: 900;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
   --bg: #0c1624;
   --bg-hero: #0f1b2b;
@@ -30,7 +62,7 @@ body {
 
 body {
   margin: 0;
-  font-family: "Titillium Web", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-family: "Titillium Web", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.6;
   color: var(--text);
@@ -73,8 +105,8 @@ h1 {
   font-size: clamp(30px, 4.5vw, 54px);
   line-height: 1.2;
   letter-spacing: -0.5px;
-  font-family: "Titillium Web", "Inter", system-ui, sans-serif;
-  font-weight: 900;
+  font-family: "Titillium Web", system-ui, sans-serif;
+  font-weight: 700;
 }
 
 h2 {
@@ -108,25 +140,13 @@ header {
 .brand {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-weight: 800;
-  letter-spacing: 0.2px;
+  height: 100%;
 }
 
 .logo {
-  width: 36px;
-  height: 36px;
-  border-radius: 999px;
-  background: conic-gradient(from 220deg, #27e5c6, #17b1a0 40%, #0ea3c0 70%, #27e5c6);
-  display: grid;
-  place-items: center;
-  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.06);
-  font-weight: 800;
-  color: #0d2233;
-}
-
-.logo::before {
-  content: "k";
+  display: block;
+  max-height: 40px;
+  width: auto;
 }
 
 .menu {


### PR DESCRIPTION
## Summary
- replace the external Google Fonts import with locally hosted Titillium Web font faces
- display the provided kontainer.sh logo in the primary navigation and keep the hero headline bold

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d85b1eb2848320810402f54e213b0f