### PR TITLE
Temporarily disable unfinished sections

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Datenschutz – kontainer.sh</title>
+    <meta
+      name="description"
+      content="Datenschutzerklärung der KONTAINER.SH GmbH – Informationen zur Verarbeitung personenbezogener Daten."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrap nav">
+        <a class="brand" href="index.html" aria-label="Startseite">
+          <img class="logo" src="KONTAINERSH_Logo_horizontal_negativ_RGB.png" alt="kontainer.sh" />
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <section class="wrap legal" aria-labelledby="datenschutz-title">
+        <h1 id="datenschutz-title">Datenschutz</h1>
+        <p>
+          Verantwortlicher für die Datenverarbeitung auf dieser Website ist die KONTAINER.SH GmbH, Wilhelm-Binder-Straße 19,
+          78048 Villingen-Schwenningen, vertreten durch Helge-Frank Zimpel. Sie erreichen uns unter
+          <a href="mailto:info@kontainer.sh">info@kontainer.sh</a> oder telefonisch unter
+          <a href="tel:+491772647770">+49&nbsp;(0)1&nbsp;77&nbsp;2&nbsp;64&nbsp;77&nbsp;70</a>.
+        </p>
+        <p>
+          Diese Website dient ausschließlich der Information über unser Leistungsangebot. Es werden keine personenbezogenen
+          Daten automatisiert analysiert, es kommen keine Tracking-, Analyse- oder Marketing-Cookies zum Einsatz. Zugriffsdaten
+          (z.&nbsp;B. IP-Adresse, Datum, Uhrzeit, abgerufene Seiten) verarbeitet der Hosting-Anbieter ausschließlich zur
+          Sicherstellung des technischen Betriebs und löscht diese automatisch nach kurzer Zeit.
+        </p>
+        <p>
+          Wenn Sie uns per E-Mail kontaktieren, werden die von Ihnen übermittelten Angaben zwecks Bearbeitung der Anfrage und
+          für den Fall von Anschlussfragen verarbeitet. Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;b DSGVO. Ihre
+          Daten werden nur so lange gespeichert, wie es für die Kommunikation notwendig ist oder gesetzliche Aufbewahrungsfristen
+          bestehen.
+        </p>
+        <p>
+          Sie haben jederzeit das Recht auf Auskunft über die bei uns gespeicherten Daten, auf deren Berichtigung oder Löschung
+          sowie auf Einschränkung der Verarbeitung, Widerspruch gegen die Verarbeitung und Datenübertragbarkeit gemäß
+          Art.&nbsp;15 ff. DSGVO. Zudem besteht ein Beschwerderecht bei einer Aufsichtsbehörde, beispielsweise dem
+          Landesbeauftragten für den Datenschutz und die Informationsfreiheit Baden-Württemberg.
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap foot">
+        <div>© <span id="year"></span> kontainer.sh</div>
+        <div class="links">
+          <a href="impressum.html">Impressum</a>
+          <span aria-hidden="true">·</span>
+          <a href="datenschutz.html" aria-current="page">Datenschutz</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://github.com/kontainer-sh" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://www.linkedin.com/in/hzimpel/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Impressum – kontainer.sh</title>
+    <meta
+      name="description"
+      content="Impressum der KONTAINER.SH GmbH – Kontaktdaten, gesetzliche Angaben und Verantwortlichkeiten."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrap nav">
+        <a class="brand" href="index.html" aria-label="Startseite">
+          <img class="logo" src="KONTAINERSH_Logo_horizontal_negativ_RGB.png" alt="kontainer.sh" />
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <section class="wrap legal" aria-labelledby="impressum-title">
+        <h1 id="impressum-title">Impressum</h1>
+        <p><strong>KONTAINER.SH GmbH</strong></p>
+        <p>
+          Wilhelm-Binder-Straße 19<br />
+          78048 Villingen-Schwenningen
+        </p>
+        <p>
+          Handelsregister: HRB 725522<br />
+          Registergericht: Amtsgericht Freiburg
+        </p>
+        <p>
+          Vertreten durch: Helge-Frank Zimpel<br />
+          Telefon: <a href="tel:+491772647770">+49 (0)1 77 2 64 77 70</a><br />
+          E-Mail: <a href="mailto:info@kontainer.sh">info@kontainer.sh</a>
+        </p>
+        <p>
+          Umsatzsteuer-Identifikationsnummer gemäß §&nbsp;27&nbsp;a Umsatzsteuergesetz:<br />
+          DE348497907
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap foot">
+        <div>© <span id="year"></span> kontainer.sh</div>
+        <div class="links">
+          <a href="impressum.html" aria-current="page">Impressum</a>
+          <span aria-hidden="true">·</span>
+          <a href="datenschutz.html">Datenschutz</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://github.com/kontainer-sh" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <span aria-hidden="true">·</span>
+          <a href="https://www.linkedin.com/in/hzimpel/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,23 @@
   </head>
   <body>
     <header>
-      <div class="wrap nav" role="navigation" aria-label="Hauptnavigation">
+      <div class="wrap nav">
         <a class="brand" href="#" aria-label="Startseite">
           <img class="logo" src="KONTAINERSH_Logo_horizontal_negativ_RGB.png" alt="kontainer.sh" />
         </a>
-        <nav class="menu" aria-label="Primäre Navigation">
-          <a href="#tutorials">Tutorials</a>
-          <a href="#oss">Open Source</a>
-          <a href="#produkte">Produkte</a>
-          <a href="#newsletter">Newsletter</a>
-          <a class="btn-ghost" href="#kontakt">Kontakt</a>
-          <a class="btn" href="#tutorials">Tutorials entdecken</a>
-        </nav>
+        <!--
+          <nav class="menu" aria-label="Primäre Navigation">
+            <a href="#tutorials">Tutorials</a>
+            <a href="#oss">Open Source</a>
+            <a href="#produkte">Produkte</a>
+            <a href="#newsletter">Newsletter</a>
+            <a class="btn-ghost" href="#kontakt">Kontakt</a>
+            <a class="btn" href="#tutorials">Tutorials entdecken</a>
+          </nav>
+
+          Navigation und Call-to-Actions werden reaktiviert, sobald die zugehörigen Inhalte
+          wieder eingebunden werden.
+        -->
       </div>
     </header>
 
@@ -35,10 +40,14 @@
           Tutorials, Templates &amp; Tools für moderne Infrastruktur. CI/CD, Kubernetes &amp; IaC – mit automatisierten Tests,
           Badges und Update-Pipelines.
         </p>
-        <div class="hero-actions">
-          <a class="btn" href="#tutorials">Tutorials entdecken</a>
-          <a class="btn-ghost" href="#starter">Starter-Kit herunterladen</a>
-        </div>
+        <!--
+          <div class="hero-actions">
+            <a class="btn" href="#tutorials">Tutorials entdecken</a>
+            <a class="btn-ghost" href="#starter">Starter-Kit herunterladen</a>
+          </div>
+
+          Hero-Aktions-Buttons folgen, sobald entsprechende Inhalte bereitstehen.
+        -->
       </section>
 
       <section class="wrap" aria-labelledby="usp">
@@ -46,7 +55,7 @@
           <article class="card k" aria-labelledby="usp1">
             <div class="pill">CI/CD</div>
             <h3 id="usp1">CI/CD Pipelines</h3>
-            <p class="muted">GitHub Actions, GitLab CI &amp; ArgoCD – praxiserprobte Workflows.</p>
+            <p class="muted">GitHub Actions, GitLab CI &amp; Flux CD – praxiserprobte Workflows.</p>
           </article>
           <article class="card k" aria-labelledby="usp2">
             <div class="pill">Kubernetes</div>
@@ -56,101 +65,106 @@
           <article class="card k" aria-labelledby="usp3">
             <div class="pill">IaC</div>
             <h3 id="usp3">IaC Templates</h3>
-            <p class="muted">Terraform/Pulumi-Bausteine für Startups &amp; KMU.</p>
+            <p class="muted">Terraform-Bausteine für Startups &amp; KMU.</p>
           </article>
         </div>
       </section>
 
-      <section id="tutorials" class="wrap" aria-labelledby="tut">
-        <h2 id="tut">Neueste Tutorials</h2>
-        <div class="grid tutorials-grid">
-          <article class="card k">
-            <h3>CI/CD mit GitHub Actions</h3>
-            <p class="muted">Workflows, Secrets, Environments &amp; Deployment-Strategien.</p>
-            <div class="badge">✅ Tested on GHA v4</div>
-          </article>
-          <article class="card k">
-            <h3>Kubernetes in 15 Minuten</h3>
-            <p class="muted">Lokales Cluster mit kind, Deployment &amp; Service.</p>
-            <div class="badge">✅ Tested on K8s v1.31</div>
-          </article>
-          <article class="card k">
-            <h3>Terraform AWS Starter</h3>
-            <p class="muted">Modulare Struktur, Provider, Remote State &amp; Workspaces.</p>
-            <div class="badge">✅ Tested on TF v1.9</div>
-          </article>
-        </div>
-      </section>
-
-      <section class="wrap">
-        <div class="grid">
-          <div id="oss" class="k8">
-            <h2>Open Source Projekte</h2>
-            <div class="grid single-column-grid">
-              <a class="card repo" href="#" aria-label="terraform-aws-starter Repo">
-                <div>
-                  <strong>kontainer-sh/terraform-aws-starter</strong>
-                  <span class="muted">Terraform-Vorlage mit Beispielen und CI.</span>
-                </div>
-                <div class="star">⭐ 112</div>
-              </a>
-              <a class="card repo" href="#" aria-label="k8s-helm-deployments Repo">
-                <div>
-                  <strong>kontainer-sh/k8s-helm-deployments</strong>
-                  <span class="muted">Helm Charts &amp; Best Practices für App-Deployments.</span>
-                </div>
-                <div class="star">⭐ 89</div>
-              </a>
-            </div>
+      <!--
+        <section id="tutorials" class="wrap" aria-labelledby="tut">
+          <h2 id="tut">Neueste Tutorials</h2>
+          <div class="grid tutorials-grid">
+            <article class="card k">
+              <h3>CI/CD mit GitHub Actions</h3>
+              <p class="muted">Workflows, Secrets, Environments &amp; Deployment-Strategien.</p>
+              <div class="badge">✅ Tested on GHA v4</div>
+            </article>
+            <article class="card k">
+              <h3>Kubernetes in 15 Minuten</h3>
+              <p class="muted">Lokales Cluster mit kind, Deployment &amp; Service.</p>
+              <div class="badge">✅ Tested on K8s v1.31</div>
+            </article>
+            <article class="card k">
+              <h3>Terraform AWS Starter</h3>
+              <p class="muted">Modulare Struktur, Provider, Remote State &amp; Workspaces.</p>
+              <div class="badge">✅ Tested on TF v1.9</div>
+            </article>
           </div>
+        </section>
 
-          <aside id="produkte" class="k4" aria-labelledby="prod">
-            <h2 id="prod">Produkte</h2>
-            <div class="grid single-column-grid">
-              <a class="card" href="#">
-                <strong>Terraform Starter Kit</strong>
-                <p class="muted">AWS-Module, Remote State, Pipelines.</p>
-                <div class="price">29 €</div>
-              </a>
-              <a class="card" href="#">
-                <strong>CI/CD Setup – Fixpreis</strong>
-                <p class="muted">In 2 Wochen produktionsreif. GitHub Actions/ArgoCD.</p>
-                <div class="price">2.500 €</div>
-              </a>
-              <a class="card" href="#">
-                <strong>E-Book „CI/CD Basics“</strong>
-                <p class="muted">Der kompakte Einstieg inkl. Checklisten.</p>
-                <div class="price">19 €</div>
-              </a>
+        <section class="wrap">
+          <div class="grid">
+            <div id="oss" class="k8">
+              <h2>Open Source Projekte</h2>
+              <div class="grid single-column-grid">
+                <a class="card repo" href="#" aria-label="terraform-aws-starter Repo">
+                  <div>
+                    <strong>kontainer-sh/terraform-aws-starter</strong>
+                    <span class="muted">Terraform-Vorlage mit Beispielen und CI.</span>
+                  </div>
+                  <div class="star">⭐ 112</div>
+                </a>
+                <a class="card repo" href="#" aria-label="k8s-helm-deployments Repo">
+                  <div>
+                    <strong>kontainer-sh/k8s-helm-deployments</strong>
+                    <span class="muted">Helm Charts &amp; Best Practices für App-Deployments.</span>
+                  </div>
+                  <div class="star">⭐ 89</div>
+                </a>
+              </div>
             </div>
-          </aside>
-        </div>
-      </section>
 
-      <section id="newsletter" class="wrap news-wrap" aria-labelledby="nl">
-        <div class="newsbar">
-          <h3 id="nl">Bleib auf dem Laufenden</h3>
-          <p class="muted">Wöchentliche DevOps-Updates – getestet &amp; kompakt.</p>
-          <form class="form" onsubmit="event.preventDefault(); alert('Danke! (Demo)');">
-            <label class="sr-only" for="mail">E-Mail</label>
-            <input class="input" id="mail" type="email" placeholder="deine@adresse.dev" required />
-            <button class="btn" type="submit">Jetzt abonnieren</button>
-          </form>
-        </div>
-      </section>
+            <aside id="produkte" class="k4" aria-labelledby="prod">
+              <h2 id="prod">Produkte</h2>
+              <div class="grid single-column-grid">
+                <a class="card" href="#">
+                  <strong>Terraform Starter Kit</strong>
+                  <p class="muted">AWS-Module, Remote State, Pipelines.</p>
+                  <div class="price">29 €</div>
+                </a>
+                <a class="card" href="#">
+                  <strong>CI/CD Setup – Fixpreis</strong>
+                  <p class="muted">In 2 Wochen produktionsreif. GitHub Actions/Flux CD.</p>
+                  <div class="price">2.500 €</div>
+                </a>
+                <a class="card" href="#">
+                  <strong>E-Book „CI/CD Basics“</strong>
+                  <p class="muted">Der kompakte Einstieg inkl. Checklisten.</p>
+                  <div class="price">19 €</div>
+                </a>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section id="newsletter" class="wrap news-wrap" aria-labelledby="nl">
+          <div class="newsbar">
+            <h3 id="nl">Bleib auf dem Laufenden</h3>
+            <p class="muted">Wöchentliche DevOps-Updates – getestet &amp; kompakt.</p>
+            <form class="form" onsubmit="event.preventDefault(); alert('Danke! (Demo)');">
+              <label class="sr-only" for="mail">E-Mail</label>
+              <input class="input" id="mail" type="email" placeholder="deine@adresse.dev" required />
+              <button class="btn" type="submit">Jetzt abonnieren</button>
+            </form>
+          </div>
+        </section>
+
+        Sobald Inhalte bereitstehen, werden die folgenden Abschnitte wieder aktiviert.
+      -->
+
     </main>
 
     <footer>
       <div class="wrap foot">
         <div>© <span id="year"></span> kontainer.sh</div>
         <div class="links">
-          <a href="#">Impressum</a>
+          <a href="impressum.html">Impressum</a>
           <span aria-hidden="true">·</span>
-          <a href="#">Datenschutz</a>
+          <a href="datenschutz.html">Datenschutz</a>
           <span aria-hidden="true">·</span>
-          <a href="https://github.com/kontainer-sh" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://github.com/kontainer-sh" target="_blank" rel="noopener noreferrer">GitHub</a>
           <span aria-hidden="true">·</span>
-          <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+          <a href="https://www.linkedin.com/in/hzimpel/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
         </div>
       </div>
     </footer>

--- a/index2.html
+++ b/index2.html
@@ -197,7 +197,7 @@ footer{padding:26px 0 48px; color:#c2d2e9; border-top:1px solid var(--line); mar
       <article class="card k" aria-labelledby="usp1">
         <div class="pill">CI/CD</div>
         <h3 id="usp1">CI/CD Pipelines</h3>
-        <p class="muted">GitHub Actions, GitLab CI &amp; ArgoCD – praxiserprobte Workflows.</p>
+        <p class="muted">GitHub Actions, GitLab CI &amp; Flux CD – praxiserprobte Workflows.</p>
       </article>
       <article class="card k" aria-labelledby="usp2">
         <div class="pill">Kubernetes</div>
@@ -207,7 +207,7 @@ footer{padding:26px 0 48px; color:#c2d2e9; border-top:1px solid var(--line); mar
       <article class="card k" aria-labelledby="usp3">
         <div class="pill">IaC</div>
         <h3 id="usp3">IaC Templates</h3>
-        <p class="muted">Terraform/Pulumi-Bausteine für Startups &amp; KMU.</p>
+        <p class="muted">Terraform-Bausteine für Startups &amp; KMU.</p>
       </article>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -230,11 +230,14 @@ header {
   font-size: 18px;
 }
 
+/*
+  Komponenten für Hero-Call-to-Actions folgen, sobald entsprechende Links wieder aktiv sind.
 .hero-actions {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
 }
+*/
 
 section {
   padding: 24px 0;
@@ -277,6 +280,8 @@ section {
   grid-column: span 12;
 }
 
+/*
+  Komponenten für Tutorials werden bei Bedarf wieder aktiviert.
 .tutorials-grid {
   margin-top: 8px;
 }
@@ -286,6 +291,8 @@ section {
   gap: 14px;
   margin-top: 8px;
 }
+
+*/
 
 .pill {
   display: inline-flex;
@@ -301,6 +308,8 @@ section {
   margin-bottom: 10px;
 }
 
+/*
+  Komponenten für Produktlisten und Newsletter werden bei Bedarf wieder aktiviert.
 .badge {
   position: absolute;
   left: 16px;
@@ -378,6 +387,7 @@ section {
 .input::placeholder {
   color: #7e96b8;
 }
+*/
 
 footer {
   padding: 26px 0 48px;
@@ -408,6 +418,31 @@ footer {
 
 .links a:hover {
   color: #fff;
+}
+
+.legal {
+  padding: 40px 0;
+}
+
+.legal h2 {
+  margin-bottom: 18px;
+}
+
+.legal p {
+  margin: 0 0 14px;
+  color: var(--muted);
+}
+
+.legal strong {
+  color: #fff;
+}
+
+.legal a {
+  color: var(--accent);
+}
+
+.legal a:hover {
+  text-decoration: underline;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- comment out the header navigation, hero calls-to-action, and lower-page sections until matching content is ready
- keep the removed sections in commented blocks on the homepage so they can be re-enabled later
- wrap the corresponding CSS rules in comments while preserving the styles that remain in use

## Testing
- Not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68d85d3945d48320ab5b69926838659d